### PR TITLE
Add link to github to homepage.

### DIFF
--- a/client/app/views/static-pages/home.view.html
+++ b/client/app/views/static-pages/home.view.html
@@ -31,5 +31,8 @@
     <p>
       The application has been developed by Jonatan Kłosko <md-icon>email</md-icon> jonatanklosko@gmail.com
     </p>
+    <p>
+      Check it out on <a href="https://github.com/jonatanklosko/internationalize">GitHub<a/>.
+    </p>
   </div>
 </div>


### PR DESCRIPTION
Having a link to github on worldcubeassociation.org found the WST one of its best developers, so I figure every website should have a link to its github =)