### PR TITLE
Fix TypeError when a conflict involves a key changing to a pluralized form

### DIFF
--- a/client/app/directives/translation-box.directive.js
+++ b/client/app/directives/translation-box.directive.js
@@ -34,7 +34,7 @@ export default () => {
           this.pluralization = processedObject._pluralization;
           this.original = processedObject._original;
           this.translated = processedObject._translated;
-          if (oldProcessedObject && !oldProcessedObject._pluralization) {
+          if (oldProcessedObject && !oldProcessedObject._pluralization && !processedObject._pluralization) {
             let diff = jsdiff.diffWordsWithSpace(oldProcessedObject._original, processedObject._original);
             let diffStrings = diff.map(part => {
               let span = document.createElement('span');

--- a/client/app/services/translation-utils.service.js
+++ b/client/app/services/translation-utils.service.js
@@ -112,9 +112,25 @@ export default class TranslationUtils {
           if(processed._translated && !_.isEqual(original._value, processed._original) && !this.isIgnoredValue(original._value)) {
             /* Scenario: a conflict - the existing original text and the new one differ. */
             newProcessed._translated = null;
+            const pluralizationChanged = !!newProcessed._pluralization !== !!processed._pluralization;
+            let initialTranslated = processed._translated;
+            if(pluralizationChanged) {
+              if(newProcessed._pluralization) {
+                initialTranslated = {};
+                pluralizationKeys.forEach(key => { initialTranslated[key] = null; });
+              } else {
+                initialTranslated = null;
+              }
+            }
+            let conflictCurrentProcessed = _.assign({}, processed, { _translated: initialTranslated });
+            if(newProcessed._pluralization) {
+              conflictCurrentProcessed._pluralization = true;
+            } else {
+              delete conflictCurrentProcessed._pluralization;
+            }
             conflicts.push({
               newOriginal: original._value,
-              currentProcessed: processed,
+              currentProcessed: conflictCurrentProcessed,
               resolve: translated => newProcessed._translated = translated
             });
           } else if(!processed._translated && translated._value && translated._originalHash && !_.isEqual(translated._originalHash, this.computeHash(original._value))) {
@@ -463,7 +479,7 @@ export default class TranslationUtils {
       return 'Translation must not be empty.';
     }
     if(variables) {
-      let variables = phrase => phrase.match(/%{.+?}/g) || [];
+      let variables = phrase => (typeof phrase === 'string' ? phrase.match(/%{.+?}/g) : null) || [];
       let originalVariables = variables(original);
       let translatedVariables = variables(translated);
       let unusedVariables = _.difference(originalVariables, translatedVariables);

--- a/spec/angular-unit/services/translation-utils.service.spec.js
+++ b/spec/angular-unit/services/translation-utils.service.spec.js
@@ -226,6 +226,25 @@ describe('TranslationUtils', () => {
         conflict.resolve('La version correcte');
         expect(result.newData.he).toEqual({ _original: 'He', _translated: 'La version correcte' });
       });
+
+      it('when a translated key changes from string to pluralized, sets _pluralization and initializes _translated', () => {
+        parsedOriginal.he = { _value: { one: '1 person', other: '%{count} people' } };
+        processedData.he = { _original: 'he', _translated: 'il' };
+        let result = TranslationUtils.buildNewData(parsedOriginal, parsedTranslated, processedData, ['zero', 'one', 'other']);
+        expect(result.conflicts.length).toEqual(1);
+
+        let conflict = result.conflicts[0];
+        expect(conflict.newOriginal).toEqual({ one: '1 person', other: '%{count} people' });
+        expect(conflict.currentProcessed._pluralization).toEqual(true);
+        expect(conflict.currentProcessed._translated).toEqual({ zero: null, one: null, other: null });
+
+        conflict.resolve({ zero: null, one: '1 personne', other: '%{count} personnes' });
+        expect(result.newData.he).toEqual({
+          _original: { one: '1 person', other: '%{count} people' },
+          _translated: { zero: null, one: '1 personne', other: '%{count} personnes' },
+          _pluralization: true
+        });
+      });
     });
 
     describe('pluralization', () => {


### PR DESCRIPTION
## Summary

- When a base-locale key changes from a plain string to a pluralized object (e.g. `{"one":"Quit Competitor from Round","other":"Quit Competitors from Round"}`), the synchronize conflict dialog crashed with `TypeError: phrase.match is not a function`.
- Root cause: `buildNewData()` passed the raw old `processed` object as `currentProcessed` in the conflict without the `_pluralization` flag, so `translation-box` treated the pluralized object as a plain string and called `.match()` on it.
- The second conflict type (outdated remote) already handled `_pluralization` correctly via `_.pick(newProcessed, ['_pluralization'])`; this fix brings the first conflict type in line.

## Changes

**`client/app/services/translation-utils.service.js`**
- In `buildNewData` (first conflict type): now propagates `_pluralization` from the new original into `currentProcessed`, and resets `_translated` appropriately when the type changes:
  - string → pluralized: `_translated` is initialized to `{ zero: null, one: null, other: null, … }` so plural input fields render in the dialog.
  - pluralized → string: `_translated` is reset to `null`.
  - same type: `_translated` is preserved (existing translation kept as starting point).
- In `translationError`: guard `phrase.match()` with `typeof phrase === 'string'` (defensive fix).

**`client/app/directives/translation-box.directive.js`**
- Skip `diffWordsWithSpace` when the new `processedObject` is pluralized, to avoid passing an object to jsdiff.

**`spec/angular-unit/services/translation-utils.service.spec.js`**
- Add a unit test for the string → pluralized conflict scenario.

## Test plan

- [x] All 66 existing angular unit tests still pass (`npm run test:angular-unit`)
- [x] New test covers the string → pluralized conflict case and asserts correct `_pluralization`, `_translated` initialization, and resolution

## Reproduction

1. Have an existing translation for a string key (e.g. `competitions.live.admin.quit.quit_confirm: "Quit Competitor from Round"` translated to `"Retirer un compétiteur du tour"`)
2. The base locale updates that key to a pluralized form: `{one: "Quit Competitor from Round", other: "Quit Competitors from Round"}`
3. Open the Synchronize dialog → `TypeError: phrase.match is not a function` in the console, conflict UI broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)